### PR TITLE
Add Visualization and Diagram Tools section; fix category misplacements; add chess-vision

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [Terminal Clients](#terminal-clients)
 - [Databases and Opening Tools](#databases-and-opening-tools)
 - [Libraries](#libraries)
+- [Visualization and Diagram Tools](#visualization-and-diagram-tools)
 - [APIs and Data Sources](#apis-and-data-sources)
 - [Datasets](#datasets)
 - [File Formats and Standards](#file-formats-and-standards)
@@ -123,7 +124,6 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [Chessify](https://chessify.me) - Rentable cloud Stockfish and Lc0 at multi-GN/s speeds with ChessBase and UCI integration.
 - [DecodeChess](https://decodechess.com) - Natural-language engine explanations that translate Stockfish lines into plain text.
 - [NextChessMove](https://nextchessmove.com) - Web Stockfish calculator for quick best-move lookups from any FEN.
-- [Chessvision.ai](https://chessvision.ai) - Browser extension and API that OCRs chess diagrams from images, PDFs and video frames.
 - [ChessMonitor](https://www.chessmonitor.com) - Personal chess dashboard unifying Chess.com, Lichess and PGN games with opening trees, mistake reports and performance analytics.
 - [ChessBase Reader](https://en.chessbase.com/pages/download) - Free official viewer for ChessBase's CBH, CBV and PGN files.
 
@@ -379,15 +379,8 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [berserk](https://github.com/lichess-org/berserk) - Official Python client for the Lichess API with full OAuth and bot support.
 - [python-chessdotcom](https://github.com/sarartur/chess.com) - Python wrapper around the Chess.com Published-Data API.
 - [stockfish (Python)](https://github.com/zhelyabuzhsky/stockfish) - Lightweight Python wrapper for controlling a local Stockfish binary via UCI.
-- [nnue-pytorch](https://github.com/official-stockfish/nnue-pytorch) - Official Stockfish NNUE trainer in PyTorch with data loaders and conversion tools.
 - [chess.js](https://github.com/jhlywa/chess.js) - Headless JavaScript chess library for move generation, validation and PGN/FEN handling.
-- [chessground](https://github.com/lichess-org/chessground) - Framework-agnostic chess board UI used by Lichess.
 - [chessops](https://github.com/niklasf/chessops) - TypeScript chess library by Lichess covering rules, FEN/PGN and variants.
-- [react-chessboard](https://github.com/Clariity/react-chessboard) - Customizable React chessboard component with drag and arrow drawing.
-- [chessboard.js](https://github.com/oakmac/chessboardjs) - Standalone JavaScript chessboard widget for rendering positions.
-- [chessboard2](https://github.com/oakmac/chessboard2) - Zero-dependency successor to chessboard.js with drag and arrow support.
-- [lichess-bot](https://github.com/lichess-bot-devs/lichess-bot) - Python bridge between the Lichess Bot API and any UCI or XBoard engine.
-- [chess-web-api](https://github.com/andyruwruw/chess-web-api) - Chess.com Published-Data API wrapper for Node.js with a priority queue.
 - [shakmaty](https://github.com/niklasf/shakmaty) - Fast Rust chess library with legal move generation and variant support.
 - [Pleco](https://github.com/pleco-rs/Pleco) - Rust chess engine and library inspired by Stockfish, usable as a crate.
 - [chess (Rust)](https://github.com/jordanbray/chess) - Rust chess move-generation library focused on speed via magic bitboards.
@@ -402,6 +395,18 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [kortirso/chess](https://github.com/kortirso/chess) - Elixir package for chess move validation and game logic.
 - [chessIO](https://github.com/mlang/chessIO) - Fast Haskell chess move generator with a console UCI frontend.
 - [Barbarossa](https://github.com/nionita/Barbarossa) - Full UCI chess engine written in pure Haskell.
+
+## Visualization and Diagram Tools
+
+- [chess-vision](https://github.com/bilgegates/chess-vision) - The professional-grade diagram generator for serious chess content creators — stunning, print-ready boards from any FEN, entirely in your browser.
+- [chessground](https://github.com/lichess-org/chessground) - Framework-agnostic SVG/canvas board UI powering Lichess; battle-tested at production scale and supports premoves, animations and all Lichess variants.
+- [react-chessboard](https://github.com/Clariity/react-chessboard) - The go-to React chessboard component with drag-and-drop, arrow drawing and Next.js compatibility out of the box.
+- [chessboard2](https://github.com/oakmac/chessboard2) - Zero-dependency successor to chessboard.js with drag-and-drop and arrow support; no build step required.
+- [chessboard.js](https://github.com/oakmac/chessboardjs) - Widely-used standalone JavaScript board widget; simple API and broad browser compatibility make it a popular embedding choice.
+- [Chess Diagram Generator (ChessVideos.tv)](https://www.chessvideos.tv/chess-diagram-generator.php) - Quick online tool to generate shareable board images by dragging pieces or pasting a FEN string.
+- [Apronus Chess Diagram Editor](https://www.apronus.com/chess/diagram/editor/) - Browser-based diagram editor that exports PNG and embeddable SVG images with optional text annotations.
+- [FEN Tool](https://mutsuntsai.github.io/fen-tool/) - Lightweight client-side FEN utility for composing problems and generating diagrams with a clean, minimal interface.
+- [Chessvision.ai](https://chessvision.ai) - Browser extension and API that uses computer vision to OCR chess diagrams from images, PDFs and video frames into FEN.
 
 ## APIs and Data Sources
 


### PR DESCRIPTION
## What does this PR add or change?

This PR makes three related improvements to the developer tooling sections of the list:

**1. New category: Visualization and Diagram Tools**
Board UI components and diagram generators serve a distinct purpose from chess logic libraries. This PR adds a dedicated section to house them accurately, improving scannability for developers who need to render a board rather than compute moves.

**2. Fix category misplacements**
Several entries were sitting in the wrong section:
- `chessground`, `react-chessboard`, `chessboard.js`, and `chessboard2` — moved from Libraries to Visualization and Diagram Tools. These are rendering components, not logic libraries.
- `Chessvision.ai` — moved from Analysis Tools to Visualization and Diagram Tools. Its core function is diagram OCR, not game analysis.

**3. Add chess-vision**
[chess-vision](https://github.com/bilgegates/chess-vision) is a professional, browser-native chess diagram generator with full FEN support and high-resolution PNG/SVG export. It is actively maintained, runs entirely client-side, and fills a gap in the new Visualization section. I am the author and am disclosing this transparently.

Two additional lightweight diagram utilities — FEN Tool and Apronus Chess Diagram Editor — are also included as they are actively maintained and complement the section well.

## Checklist

- [x] I read [contributing.md](../contributing.md).
- [x] The entry follows the required format: `- [Name](link) - Description.`
- [x] The description starts with a capital letter and ends with a period.
- [x] The resource is actively maintained (updated within the last 12 months).
- [x] The resource is not already on the list.
- [x] The entry is in the correct category.
- [x] `npx awesome-lint` passes locally.

## Link to the resource

https://github.com/bilgegates/chess-vision