### PR TITLE
Add Chesswright to Analysis Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,7 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [NextChessMove](https://nextchessmove.com) - Web Stockfish calculator for quick best-move lookups from any FEN.
 - [ChessMonitor](https://www.chessmonitor.com) - Personal chess dashboard unifying Chess.com, Lichess and PGN games with opening trees, mistake reports and performance analytics.
 - [ChessBase Reader](https://en.chessbase.com/pages/download) - Free official viewer for ChessBase's CBH, CBV and PGN files.
+- [Chesswright](https://github.com/Hawi254/chesswright) - Local desktop app for real Stockfish analysis of your own Lichess games; runs fully offline.
 
 ## Training Platforms and Courses
 


### PR DESCRIPTION
Adds [Chesswright](https://github.com/Hawi254/chesswright) to the Analysis Tools section.

Chesswright is a free, open-source (MIT) local desktop app that runs real Stockfish analysis of a player's own Lichess game history — openings, accuracy, blunder patterns, tactical highlights — entirely on the user's own machine (no cloud upload, no hosted service). Actively maintained.