### PR TITLE
Add BetterBullet to Analysis Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,7 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [NextChessMove](https://nextchessmove.com) - Web Stockfish calculator for quick best-move lookups from any FEN.
 - [ChessMonitor](https://www.chessmonitor.com) - Personal chess dashboard unifying Chess.com, Lichess and PGN games with opening trees, mistake reports and performance analytics.
 - [ChessBase Reader](https://en.chessbase.com/pages/download) - Free official viewer for ChessBase's CBH, CBV and PGN files.
+- [BetterBullet](https://betterbullet.xyz) - Bullet-specific pacing analyzer comparing your 1+0 clock use to rating-band benchmarks.
 
 ## Training Platforms and Courses
 


### PR DESCRIPTION
## What does this PR add or change?

Adds BetterBullet to Analysis Tools.

BetterBullet is a bullet-chess (1+0) pacing analyzer: it charts where a player's time
goes across a 60-second game, move by move, against rating-band pacing benchmarks built
from the Lichess open database (CC0). Works with both Lichess and Chess.com accounts;
analysis runs locally in the browser.

Why it belongs on the list:
- Active and maintained (launching now, updated within the last 12 months).
- Distinct value: no existing entry does bullet-specific clock/pacing analysis; the
  closest (ChessMonitor) is a general multi-site dashboard.
- Not a paywalled black box — there's a full free demo report, no account required, and
  a one-time price (no subscription).

Disclosure: I'm the developer.

## Checklist

- [x] I read [contributing.md](https://github.com/atamano/awesome-chess/blob/main/contributing.md).
- [x] The entry follows the required format: `- [Name](link) - Description.`
- [x] The description starts with a capital letter and ends with a period.
- [x] The resource is actively maintained (updated within the last 12 months).
- [x] The resource is not already on the list.
- [x] The entry is in the correct category (Analysis Tools, added at the bottom).
- [x] `npx awesome-lint` passes locally — the entry introduces no lint issues; the only
      warnings on my fork are its missing `awesome`/`awesome-list` GitHub topics, which
      don't apply to this upstream repo.

## Link to the resource

https://betterbullet.xyz