### PR TITLE
Add fenshot (open-source screenshot to FEN, in-browser)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -409,6 +409,7 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [Apronus Chess Diagram Editor](https://www.apronus.com/chess/diagram/editor/) - Browser-based diagram editor that exports PNG and embeddable SVG images with optional text annotations.
 - [FEN Tool](https://mutsuntsai.github.io/fen-tool/) - Lightweight client-side FEN utility for composing problems and generating diagrams with a clean, minimal interface.
 - [Chessvision.ai](https://chessvision.ai) - Browser extension and API that OCRs chess diagrams from images, PDFs and video frames.
+- [fenshot](https://github.com/scoriiu/fenshot) - Open-source screenshot-to-FEN recognition running entirely in the browser, reads site screenshots and book diagrams and opens them on Lichess.
 
 ## APIs and Data Sources
 


### PR DESCRIPTION
Adds [fenshot](https://github.com/scoriiu/fenshot) next to Chessvision.ai in Visualization and Diagram Tools, it is the open-source counterpart: screenshot or book diagram in, FEN out, running fully client side (onnxruntime wasm, MIT, also published on npm as `@scoriiu/fenshot`).

- Live demo: https://scoriiu.github.io/fenshot/
- Reads chess.com/Lichess screenshots and book diagrams, auto-detects Black-POV screenshots and flips
- Golden regression suite against real screenshots in the repo; training pipeline included so the model is reproducible