### PR TITLE
Add Chessnote to Openings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [OpeningTree](https://www.openingtree.com) - Visualizes your own Chess.com or Lichess games as an opening tree.
 - [ChessAtlas](https://chessatlas.net) - Spaced-repetition trainer for memorizing and maintaining your opening repertoire.
 - [Opening Scanner](https://openingscanner.com) - Client-side tool that reveals any Lichess or Chess.com player's actual repertoire with ECO classification and win rates.
+- [Chessnote](https://chessnote.io) - Interactive tool to visualize opening variations and build a personal repertoire, free to start.
 
 ## Endgames
 


### PR DESCRIPTION
Adds [Chessnote](https://chessnote.io) to the **Openings** section.

**What it is:** an interactive tool for learning chess openings visually — you step through opening variations on an interactive board and build a personal repertoire, rather than memorizing move lists.

**Why it fits this section:** it sits alongside the existing repertoire-building / opening-trainer entries (Chessbook, Chessreps, ChessAtlas) but leads with visual, move-by-move exploration.

**Meets the guidelines:**
- Format: `- [Name](link) - Description.` — capitalized, ends with a period, 96 chars (< 100).
- Added to the bottom of the Openings category (not alphabetized), per contributing.md.
- **Actively maintained** — updated in 2026, with a regularly published blog.
- **Free to start** (freemium) — not a paywalled black box; has a genuine free tier.
- Available in English.

Happy to adjust the wording or placement if you'd prefer.