### PR TITLE
Add Chess Report to Analysis Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,7 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [NextChessMove](https://nextchessmove.com) - Web Stockfish calculator for quick best-move lookups from any FEN.
 - [ChessMonitor](https://www.chessmonitor.com) - Personal chess dashboard unifying Chess.com, Lichess and PGN games with opening trees, mistake reports and performance analytics.
 - [ChessBase Reader](https://en.chessbase.com/pages/download) - Free official viewer for ChessBase's CBH, CBV and PGN files.
+- [Chess Report](https://chess-report.com) - Free scan of your Lichess or Chess.com games that finds the biggest fixable leak in your play and what it costs in Elo.
 
 ## Training Platforms and Courses
 


### PR DESCRIPTION
Adds [Chess Report](https://chess-report.com) — a free, no-signup scan of a player's public Lichess or Chess.com games. It builds a descriptive report (opening performance vs rating expectation, tilt/session patterns, time-loss anatomy) and ranks the biggest fixable leak by estimated Elo cost. Every stat shows its sample size.