### PR TITLE
Add Checkmate Elo to Desktop GUIs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -352,6 +352,7 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [XBoard](https://www.gnu.org/software/xboard/) - GNU Project's reference GUI, still maintained for Unix, Windows and macOS.
 - [ChessBase](https://shop.chessbase.com/en/categories/chessbase-cb) - Commercial industry-standard database and analysis suite used by top professionals.
 - [Lucas Chess R](https://lucaschess.pythonanywhere.com) - Free Windows and Linux training GUI with tactics, tutors and built-in engines.
+- [Checkmate Elo](https://github.com/Vangaurdd/checkmate-elo) - Rated chess GUI for macOS with chess.com-calibrated AI and Stockfish-powered move review.
 
 ## Terminal Clients
 


### PR DESCRIPTION
Adds [Checkmate Elo](https://github.com/Vangaurdd/checkmate-elo), a macOS chess GUI I built. It plays against you with an AI whose search depth is calibrated in bands to roughly track chess.com's rating tiers (so a 1000-rated player faces a moderate opponent, not full engine strength), keeps a persistent rating and game history across sessions, and includes a post-game Game Review powered by Stockfish that scores every move 1-10 using the same win-percentage accuracy formula Lichess documents publicly.

It's actively maintained (latest release this week) and open source (MIT-style permissive use, piece art is CC BY-SA/GPL2+, Stockfish is bundled under GPLv3 with attribution in the README).