### PR TITLE
Add chess.rodeo to Analysis Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ Chess has grown into a vast ecosystem of servers, software, media, and open-sour
 - [NextChessMove](https://nextchessmove.com) - Web Stockfish calculator for quick best-move lookups from any FEN.
 - [ChessMonitor](https://www.chessmonitor.com) - Personal chess dashboard unifying Chess.com, Lichess and PGN games with opening trees, mistake reports and performance analytics.
 - [ChessBase Reader](https://en.chessbase.com/pages/download) - Free official viewer for ChessBase's CBH, CBV and PGN files.
+- [chess.rodeo](https://chess.rodeo) - Imports Chess.com, Lichess and PGN games for a Stockfish review with move labels and accuracy.
 
 ## Training Platforms and Courses
 


### PR DESCRIPTION
**Disclosure:** I'm the founder — self-submission, flagged per the rules.

chess.rodeo imports a game (Chess.com/Lichess username or a PGN) and returns a Stockfish review: every move labelled, a Lichess-compatible accuracy score, an eval graph and opening detection over 3,000+ ECO lines. Free and in-browser (Stockfish 18), no account or daily limit; Pro adds server-side analysis and greater depth.

**Hidden Gem** (online ~10 months, no third-party coverage yet):

- **Closest / difference:** vs ChessMonitor (multi-account dashboard) and Chess.com Game Review (account-bound report), chess.rodeo reviews any imported or pasted game with no account, then adds a rules-based coach that walks the game and drills your own mistakes — claiming only what the board proves (fork, pin, hanging piece, mate in N).
- **Usable today:** live, plus a Chrome extension, opening courses, an SRS repertoire trainer, puzzles, Play vs AI and a 16-language UI.
- **Quality evidence:** a working, non-trivial implementation and a public methodology — https://chess.rodeo/blog/how-to-analyze-chess-games.
